### PR TITLE
Fix label-for association of the Flip mouth checkbox

### DIFF
--- a/public/editor.html
+++ b/public/editor.html
@@ -635,7 +635,7 @@
                         checked
                         id="mouth-flip"
                       />
-                      <label class="form-check-label" for="hair-flip">
+                      <label class="form-check-label" for="mouth-flip">
                         Flip
                       </label>
                     </div>


### PR DESCRIPTION
On the web-based editor, clicking on the label "Flip" for Mouth toggles the checkbox for Flip under Hair. This is due to the incorrect `label-for` value being present on the label. This PR fixes the association of the label to the correctly corresponding checkbox.